### PR TITLE
Fixed issue with .iteritems with Python3 I was experiencing

### DIFF
--- a/crowd_api/__init__.py
+++ b/crowd_api/__init__.py
@@ -283,7 +283,7 @@ class CrowdAPI:
     def create_user(self, **kwargs):
         user = {}
 
-        for k, v in kwargs.iteritems():
+        for k, v in kwargs.items():
             user[k.replace('_', '-')] = v
 
         if 'password' not in kwargs:


### PR DESCRIPTION
Whenever I was trying to use this package with Python3 in my environment I was always getting a python error with regards to `kwargs.iteritems()` that the package is written with! Hope this helps some people!