### PR TITLE
Fix broken URL templating for get_group_users

### DIFF
--- a/crowd_api/__init__.py
+++ b/crowd_api/__init__.py
@@ -102,7 +102,7 @@ class CrowdAPI:
         if "groupname" not in kwargs:
             raise ValueError("Must pass username")
 
-        req = self.api_get("/group/user/direct?groupname={}&max-results={}}&start-index={}".format(
+        req = self.api_get("/group/user/direct?groupname={}&max-results={}&start-index={}".format(
             kwargs['groupname'], kwargs.get('max_results', 1000), kwargs.get('start_index', 0)))
         if req.status_code == 200:
             for user in req.json()['users']:

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from distutils.core import setup
 
-version = '0.0.9'
+version = '0.0.10'
 
 setup(
   name='crowd-api',


### PR DESCRIPTION
Hey @m4ce,

we have encountered the error below while trying to use the `get_group_users()` method from the library. It looks like a simple fix to us.
We would appreciate if you could merge this and then create a release for the lib. Thank you!

```sh
  File "/root/.cache/pypoetry/virtualenvs/xxxxxxxxxxxx/lib/python3.11/site-packages/crowd_api/__init__.py", line 134, in get_group_users
    req = self.api_get("/group/user/direct?groupname={}&max-results={}}&start-index={}".format(
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ValueError: Single '}' encountered in format string
```