### PR TITLE
Extend usermanagement requests

### DIFF
--- a/crowd_api/__init__.py
+++ b/crowd_api/__init__.py
@@ -197,6 +197,35 @@ class CrowdAPI:
         else:
             return {"status": False, "code": req.status_code, "reason": req.content}
 
+    def get_direct_children_of_group(self, **kwargs) -> dict:
+        """Retrieve the groups that are direct children of the specified group."""
+        endpoint = "/group/child-group/direct"
+
+        if "groupname" not in kwargs:
+            raise ValueError("Must pass groupname")
+
+        params = {'groupname': kwargs['groupname']}
+
+        if kwargs.get('max_results') is not None:
+            params['max-results'] = kwargs.get('max_results')
+        if kwargs.get('start_index') is not None:
+            params['start-index'] = kwargs.get('start_index')
+
+        query = f"{endpoint}?{urlencode(params)}"
+
+        req = self.crowd.api_get(query)
+
+        groups = []
+
+        if req.status_code == 200:
+            for group in req.json()['groups']:
+                groups.append(group['name'])
+            return {"status": True, "groups": groups}
+        if req.status_code == 404:
+            return {"status": False, "groups": []}
+        else:
+            return {"status": False, "code": req.status_code, "reason": req.content}
+
     def get_all_groups(self, **kwargs):
         groups = []
 

--- a/crowd_api/__init__.py
+++ b/crowd_api/__init__.py
@@ -97,6 +97,35 @@ class CrowdAPI:
         else:
             return {"status": False, "code": req.status_code, "reason": req.content}
 
+    def get_nested_user_groups(self, **kwargs) -> dict:
+        """Retrieve the group that the user is a nested member of."""
+        endpoint = "/user/group/nested"
+
+        if "username" not in kwargs:
+            raise ValueError("Must pass username")
+
+        params = {'username': kwargs['username']}
+
+        if kwargs.get('max_results') is not None:
+            params['max-results'] = kwargs.get('max_results')
+        if kwargs.get('start_index') is not None:
+            params['start-index'] = kwargs.get('start_index')
+
+        query = f"{endpoint}?{urlencode(params)}"
+
+        req = self.crowd.api_get(query)
+
+        groups = []
+
+        if req.status_code == 200:
+            for group in req.json()['groups']:
+                groups.append(group['name'])
+            return {"status": True, "groups": groups}
+        if req.status_code == 404:
+            return {"status": False, "groups": []}
+        else:
+            return {"status": False, "code": req.status_code, "reason": req.content}
+
     def get_group_users(self, **kwargs):
         users = []
 

--- a/crowd_api/__init__.py
+++ b/crowd_api/__init__.py
@@ -226,6 +226,35 @@ class CrowdAPI:
         else:
             return {"status": False, "code": req.status_code, "reason": req.content}
 
+    def get_nested_children_of_group(self, **kwargs) -> dict:
+        """Retrieve nested children of the specified group."""
+        endpoint = "/group/child-group/nested"
+
+        if "groupname" not in kwargs:
+            raise ValueError("Must pass groupname")
+
+        params = {'groupname': kwargs['groupname']}
+
+        if kwargs.get('max_results') is not None:
+            params['max-results'] = kwargs.get('max_results')
+        if kwargs.get('start_index') is not None:
+            params['start-index'] = kwargs.get('start_index')
+
+        query = f"{endpoint}?{urlencode(params)}"
+
+        req = self.crowd.api_get(query)
+
+        groups = []
+
+        if req.status_code == 200:
+            for group in req.json()['groups']:
+                groups.append(group['name'])
+            return {"status": True, "groups": groups}
+        if req.status_code == 404:
+            return {"status": False, "groups": []}
+        else:
+            return {"status": False, "code": req.status_code, "reason": req.content}
+
     def get_all_groups(self, **kwargs):
         groups = []
 

--- a/crowd_api/__init__.py
+++ b/crowd_api/__init__.py
@@ -8,6 +8,7 @@ import requests
 import json
 import random
 import string
+from urllib.parse import urlencode
 
 
 class CrowdAPI:
@@ -162,6 +163,34 @@ class CrowdAPI:
             for group in req.json()['groups']:
                 groups.append(group['name'])
 
+            return {"status": True, "groups": groups}
+        if req.status_code == 404:
+            return {"status": False, "groups": []}
+        else:
+            return {"status": False, "code": req.status_code, "reason": req.content}
+
+    def get_nested_parent_groups(self, **kwargs) -> dict:
+        """Retrieve the groups that are nested parents of the specified group."""
+        endpoint = "/group/parent-group/nested"
+
+        if "groupname" not in kwargs:
+            raise ValueError("Must pass groupname")
+
+        params = {'groupname': kwargs['groupname']}
+
+        if kwargs.get('max_results') is not None:
+            params['max-results'] = kwargs.get('max_results')
+        if kwargs.get('start_index') is not None:
+            params['start-index'] = kwargs.get('start_index')
+
+        query = f"{endpoint}?{urlencode(params)}"
+
+        req = self.crowd.api_get(query)
+
+        groups = []
+        if req.status_code == 200:
+            for group in req.json()['groups']:
+                groups.append(group['name'])
             return {"status": True, "groups": groups}
         if req.status_code == 404:
             return {"status": False, "groups": []}

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from distutils.core import setup
 
-version = '0.0.10'
+version = '0.1.0'
 
 setup(
   name='crowd-api',


### PR DESCRIPTION
Here are the methods that have been added:

## information on user:

* `get_nested_user_groups`
implements: Get nested groups
Description: Retrieve the group that the user is a nested member of.

## information on group:

* `get_nested_children_of_group`
implements: Get nested children of group
Description: Retrieve nested children of the specified group.

* `get_direct_children_of_group`
implements: Get direct children of group
Description: Retrieve the groups that are direct children of the specified group.

* `get_nested_parent_groups`
implements: Get nested parent groups
Description: Retrieve the groups that are nested parents of the specified group.

Reference API: https://docs.atlassian.com/atlassian-crowd/5.3.2/REST/

To remain consistent with the previous methods, I have maintained the use of a single unnamed parameter (kwargs), kept same error handling, the return type (dict), as well as the creation of the URL with parameters.

Some improvements have been made compared to the previously implemented methods:

- Use of f-strings instead of `str.format()`, as introduced by PEP 498 (2015): [PEP 498](https://peps.python.org/pep-0498/).
- Separation of the endpoint and use of URL encoding and dictionaries for URL creation, allowing for uniform URL construction.
- Ability to use the `max-results` and `start-index` parameters of the API while retaining default values.